### PR TITLE
Fixed Text Box Printing Bug

### DIFF
--- a/Configs/Default.config.gmx
+++ b/Configs/Default.config.gmx
@@ -657,9 +657,11 @@
     <option_xbone_title_id></option_xbone_title_id>
   </Options>
   <ConfigConstants>
-    <constants number="2">
+    <constants number="4">
       <constant name="DEFAULT_COLOR">c_white</constant>
+      <constant name="TEXT_BOX_COLOR">c_white</constant>
       <constant name="DEFAULT_FONT">Font_PGothic</constant>
+      <constant name="TEXT_BOX_FONT">Font_PGothic</constant>
     </constants>
   </ConfigConstants>
 </Config>

--- a/JesseDayInTheLife.project.gmx
+++ b/JesseDayInTheLife.project.gmx
@@ -18,6 +18,8 @@
   <backgrounds name="background"/>
   <paths name="paths"/>
   <scripts name="scripts">
+    <script>scripts\pad_text_for_display.gml</script>
+    <script>scripts\split_string.gml</script>
     <script>scripts\text_box_create.gml</script>
   </scripts>
   <fonts name="fonts">
@@ -32,10 +34,6 @@
   <rooms name="rooms">
     <room>rooms\Room_Test</room>
   </rooms>
-  <constants number="2">
-    <constant name="TEXT_COLOR">c_white</constant>
-    <constant name="TEXT_BOX_FONT">Font_PGothic</constant>
-  </constants>
   <help>
     <rtf>help.rtf</rtf>
   </help>

--- a/objects/Obj_TextBox.object.gmx
+++ b/objects/Obj_TextBox.object.gmx
@@ -28,6 +28,11 @@
             <string>time = 0
 textLength = 0
 print = ""
+boxPadding = 24 
+textSizeMultiplyer = 1.2 // Makes text bigger
+windowHeightPadding = 0.6
+
+maxWidth = (window_get_width() - boxPadding)
 show_debug_message("textboxObject_create")
 </string>
           </argument>
@@ -45,7 +50,7 @@ show_debug_message("textboxObject_create")
         <exetype>2</exetype>
         <functionname></functionname>
         <codestring></codestring>
-        <whoName>self</whoName>
+        <whoName>other</whoName>
         <relative>0</relative>
         <isnot>0</isnot>
         <arguments>
@@ -69,27 +74,24 @@ draw_sprite_stretched (
     Spr_TextBox,
     -1,
     0,
-    window_get_height() * 0.6,
+    window_get_height() * windowHeightPadding,
     window_get_width(),
-    window_get_height() * 0.4,
+    window_get_height() * (1 - windowHeightPadding),
 )
 
-boxPadding = 24 
-textRatioIncrease = 1.5 // scale to this much idk 
-
 draw_set_font(TEXT_BOX_FONT)
-draw_set_color(TEXT_COLOR)
+draw_set_color(TEXT_BOX_COLOR)
 texture_set_interpolation(true)
 
 fontSize = font_get_size(TEXT_BOX_FONT)
 draw_text_ext_transformed (
-    0  + boxPadding,
-    (window_get_height() * 0.6) + boxPadding,
+    boxPadding,
+    (window_get_height() * windowHeightPadding) + boxPadding,
     print,
-    (fontSize*1.5),
-    (window_get_width() - boxPadding) / textRatioIncrease,
-    textRatioIncrease,
-    textRatioIncrease,
+    (fontSize*textSizeMultiplyer),
+    maxWidth / textSizeMultiplyer,
+    textSizeMultiplyer,
+    textSizeMultiplyer,
     0 // angle
 )
 

--- a/scripts/pad_text_for_display.gml
+++ b/scripts/pad_text_for_display.gml
@@ -1,0 +1,44 @@
+/// pad_text_for_display("Text", maxWidth, textSizeMultiplyer)
+// Assumes no new line charactures are present
+
+var text = argument0
+var maxWidth = argument1
+var textSizeMultiplyer = argument2
+var spaceWidth = string_width(" ") * textSizeMultiplyer
+
+var textWordArray = split_string(text, ' ')
+
+var paddedText = ""
+var currentLine = ""
+draw_set_font(TEXT_BOX_FONT) // set font so string_width gets accurate values
+
+for(i = 0; i < array_length_1d(textWordArray); i++) {
+    currentWord = textWordArray[i]
+    newLineWidth = ((string_width(currentLine) + string_width(currentWord)) * textSizeMultiplyer ) + spaceWidth
+    if newLineWidth > maxWidth {
+        if paddedText != "" { // don't add new line for first line
+            paddedText += "#"
+        }
+        paddedText += currentLine
+        currentLine = currentWord
+    } else { // add the word to the line
+        if currentLine != "" {
+            currentLine += " "
+        }
+        currentLine += currentWord 
+    }
+}
+
+if currentLine != "" { // add the final line
+    if paddedText != "" {
+        paddedText += "#"
+    }
+    paddedText += currentLine
+}
+
+draw_set_font(DEFAULT_FONT)
+
+show_debug_message(paddedText)
+
+ return paddedText
+

--- a/scripts/split_string.gml
+++ b/scripts/split_string.gml
@@ -1,0 +1,32 @@
+/// split_string("Text", delimiter)
+// splits string with delimiter
+
+var text = argument0
+var delimiter = argument1
+
+var currentWord = "" // the current word
+var arrayPlacement = 0 // current end of array
+var wordArray // the array of words
+
+show_debug_message(text)
+for(i = 1; i <= string_length(text); i++) {
+    char = string_char_at(text, i)
+    if char == delimiter {
+        if string_length(currentWord) != 0 {
+            wordArray[arrayPlacement] = currentWord
+            currentWord = ""
+            arrayPlacement++
+        }
+    } else {
+        currentWord += char
+    }
+}
+
+if string_length(currentWord) != 0 {
+    wordArray[arrayPlacement] = currentWord
+}
+
+show_debug_message(wordArray)
+
+return wordArray
+

--- a/scripts/text_box_create.gml
+++ b/scripts/text_box_create.gml
@@ -1,7 +1,7 @@
+/// text_box_create("Text", speed, x, y)
 //based off of tutorial found here 
 //https://www.youtube.com/watch?v=HdJ0ZUIs-AI
 
-// textBox_script("Text", speed, x, y)
 // description: function creates a textbox with associated text and prints each letter at associated speed
 
 // argument0 and argument1 used because gamemaker will not let you use varables defined within scripts in with blocks
@@ -9,13 +9,13 @@
 var xPosition = argument2
 var yPosition = argument3
 
-var textLimit = 140; // hard coded lmao. Make dynamic in future update
-argument0 = string_copy(argument0, 1, 140) // hacky way to get around gamemaker script with block limitation
+var textLimit = 140 // hard coded lmao. Make dynamic in future update
+argument0 = string_copy(argument0, 1, textLimit) // hacky way to get around gamemaker script with block limitation
 
 textBox = instance_create(xPosition, yPosition, Obj_TextBox)
     
 with(textBox) {
-    text = argument0
+    text = pad_text_for_display(argument0, maxWidth, textSizeMultiplyer)
     displaySpeed = argument1
         
     textLength = string_length(text)


### PR DESCRIPTION
 - Fixed a bug where text would run off the screen for brief moments, because it was not taking the whole word into account before printing.
 - Added some helpful scripts (string display padding and splitting string with delimiter)
 - A bit of general code cleanup